### PR TITLE
Add functions for (de)serializing lists of elements

### DIFF
--- a/c_src/erlang_pbc.c
+++ b/c_src/erlang_pbc.c
@@ -868,6 +868,10 @@ pbc_binary_to_elements(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
+    if (!enif_is_binary(env, argv[1])) {
+        return enif_make_badarg(env);
+    }
+
     struct pbc_element *element;
     struct pbc_group *group;
     if (enif_get_resource(env, argv[0], PBC_ELEMENT_RESOURCE, (void**)&element)) {

--- a/c_src/erlang_pbc.c
+++ b/c_src/erlang_pbc.c
@@ -816,6 +816,104 @@ pbc_binary_to_element(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 }
 
 static ERL_NIF_TERM
+pbc_elements_to_binary(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
+{
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_is_list(env, argv[0])) {
+        return enif_make_badarg(env);
+    }
+    unsigned int in_len = 0;
+
+    if (!enif_get_list_length(env, argv[0], &in_len)) {
+        return enif_make_badarg(env);
+    }
+
+    ERL_NIF_TERM in_list = argv[0];
+    ERL_NIF_TERM out_list = enif_make_list(env, 0);
+    ERL_NIF_TERM cur;
+    struct pbc_element *element;
+
+    while(enif_get_list_cell(env, in_list, &cur, &in_list)) {
+        if (!enif_get_resource(env, cur, PBC_ELEMENT_RESOURCE, (void**)&element)) {
+            return enif_make_badarg(env);
+        }
+
+        int bytes = element_length_in_bytes(element->element);
+
+        ErlNifBinary bin;
+        if (!enif_alloc_binary(bytes+1, &bin)) {
+            return enif_make_badarg(env);
+        }
+
+        bin.data[0] = (uint8_t) element->field;
+        element_to_bytes(bin.data+1, element->element);
+        out_list = enif_make_list_cell(env, enif_make_binary(env, &bin), out_list);
+    }
+
+    ErlNifBinary result;
+
+    enif_term_to_binary(env, out_list, &result);
+
+    return enif_make_binary(env, &result);
+}
+
+static ERL_NIF_TERM
+pbc_binary_to_elements(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
+{
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
+    struct pbc_element *element;
+    struct pbc_group *group;
+    if (enif_get_resource(env, argv[0], PBC_ELEMENT_RESOURCE, (void**)&element)) {
+        group = element->group;
+    } else if (!enif_get_resource(env, argv[0], PBC_GROUP_RESOURCE, (void**)&group)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary bin;
+    if (!enif_inspect_binary(env, argv[1], &bin)) {
+        return enif_make_badarg(env);
+    }
+
+    ERL_NIF_TERM in_list = argv[0];
+    ERL_NIF_TERM out_list = enif_make_list(env, 0);
+    ERL_NIF_TERM cur;
+
+    if (!enif_binary_to_term(env, bin.data, bin.size, &in_list, ERL_NIF_BIN2TERM_SAFE)) {
+        return enif_make_badarg(env);
+    }
+
+    unsigned int in_len = 0;
+
+    if (!enif_get_list_length(env, in_list, &in_len)) {
+        return enif_make_badarg(env);
+    }
+
+    ERL_NIF_TERM args[2];
+    args[0] = argv[0];
+
+    while(enif_get_list_cell(env, in_list, &cur, &in_list)) {
+        if (!enif_inspect_binary(env, cur, &bin)) {
+            return enif_make_badarg(env);
+        }
+
+        args[1] = cur;
+
+        cur = pbc_binary_to_element(env, argc, args);
+
+        out_list = enif_make_list_cell(env, cur, out_list);
+    }
+
+    return out_list;
+}
+
+static ERL_NIF_TERM
 pbc_element_cmp(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 {
     if (argc != 2) {
@@ -1110,6 +1208,8 @@ static ErlNifFunc nif_funcs[] = {
     {"element_to_string", 1, pbc_element_to_string, 0},
     {"element_to_binary", 1, pbc_element_to_binary, 0},
     {"binary_to_element", 2, pbc_binary_to_element, 0},
+    {"elements_to_binary", 1, pbc_elements_to_binary, 0},
+    {"binary_to_elements", 2, pbc_binary_to_elements, 0},
     {"element_cmp", 2, pbc_element_cmp, 0},
     {"element_pairing", 2, pbc_element_pairing, 0},
     {"pairing_is_symmetric", 1, pbc_pairing_is_symmetric, 0},

--- a/src/erlang_pbc.erl
+++ b/src/erlang_pbc.erl
@@ -1,5 +1,5 @@
 -module(erlang_pbc).
--export([group_new/1, group_order/1, element_new/2, element_to_string/1, element_random/1, element_add/2, element_sub/2, element_mul/2, element_div/2, element_pow/2, element_neg/1, element_set/2, element_from_hash/2, element_to_binary/1, binary_to_element/2, element_cmp/2, element_pairing/2, pairing_is_symmetric/1, element_pp_init/1, pairing_pp_init/1, element_is0/1, element_is1/1, enable_pp_counts/2]).
+-export([group_new/1, group_order/1, element_new/2, element_to_string/1, element_random/1, element_add/2, element_sub/2, element_mul/2, element_div/2, element_pow/2, element_neg/1, element_set/2, element_from_hash/2, element_to_binary/1, binary_to_element/2, elements_to_binary/1, binary_to_elements/2, element_cmp/2, element_pairing/2, pairing_is_symmetric/1, element_pp_init/1, pairing_pp_init/1, element_is0/1, element_is1/1, enable_pp_counts/2]).
 -on_load(init/0).
 
 -type element() :: reference().
@@ -155,6 +155,14 @@ element_to_binary(_) ->
 
 -spec binary_to_element(element(), binary()) -> element().
 binary_to_element(_, _) ->
+    not_loaded(?LINE).
+
+-spec elements_to_binary([element()]) -> binary().
+elements_to_binary(_) ->
+    not_loaded(?LINE).
+
+-spec binary_to_elements(element(), binary()) -> [element()].
+binary_to_elements(_, _) ->
     not_loaded(?LINE).
 
 -spec element_cmp(element(), element()) -> boolean().


### PR DESCRIPTION
This is helpful when you have many, many elements to serialize/deserialize and want to do it them all at once, rather than making N nif calls.