### PR TITLE
Fix macOS build

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 # NIF                                                                    #
 ##########################################################################
 find_package(Erlang REQUIRED)
+find_package(GMP REQUIRED)
 find_package(PBC REQUIRED)
 add_library(erlang_pbc MODULE erlang_pbc.c)
 target_link_libraries(erlang_pbc

--- a/c_src/cmake/FindGMP.cmake
+++ b/c_src/cmake/FindGMP.cmake
@@ -1,0 +1,76 @@
+#[=======================================================================[.rst:
+FindGMP
+-------
+
+Find the GNU MULTI-Precision Bignum (GMP) library.
+
+This module is derived from [1]. It is modified to remove the GMPxx
+requirement.
+
+[1]: https://github.com/dune-project/dune-common/blob/b3ee0b735d1818d34fff16aed57656ab707df628/cmake/modules/FindGMP.cmake
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``GMP::gmp``
+  Library target of the C library.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``GMP_FOUND``
+  True if the GMP library and header were found.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+You may set the following variables to modify the behaviour of
+this module:
+
+``GMP_INCLUDE_DIR``
+  The directory containing ``gmp.h``.
+``GMP_LIB``
+  The path to the gmp library.
+
+#]=======================================================================]
+
+# Add a feature summary for this package
+include(FeatureSummary)
+set_package_properties(GMP PROPERTIES
+  DESCRIPTION "GNU multi-precision library"
+  URL "https://gmplib.org"
+  )
+
+# Try finding the package with pkg-config
+find_package(PkgConfig QUIET)
+pkg_check_modules(PKG QUIET gmp gmpxx)
+
+# Try to locate the libraries and their headers, using pkg-config hints
+find_path(GMP_INCLUDE_DIR gmp.h HINTS ${PKG_gmp_INCLUDEDIR})
+find_library(GMP_LIB gmp HINTS ${PKG_gmp_LIBDIR})
+
+# Remove these variables from cache inspector
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIB)
+
+# Report if package was found
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMP
+  DEFAULT_MSG
+  GMP_INCLUDE_DIR GMP_LIB
+  )
+
+# Set targets
+if(GMP_FOUND)
+  # C library
+  if(NOT TARGET GMP::gmp)
+    add_library(GMP::gmp UNKNOWN IMPORTED)
+    set_target_properties(GMP::gmp PROPERTIES
+      IMPORTED_LOCATION ${GMP_LIB}
+      INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
+      )
+  endif()
+endif()

--- a/c_src/cmake/FindPBC.cmake
+++ b/c_src/cmake/FindPBC.cmake
@@ -9,6 +9,7 @@ endif()
 ExternalProject_Add(pbc
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/external-pbc
   GIT_REPOSITORY    https://github.com/Vagabond/pbc
+  GIT_TAG           cbe5718309e2c34345a35eb76731fb81122f0d79
   UPDATE_COMMAND    ""
   BUILD_IN_SOURCE   1
   CONFIGURE_COMMAND autoreconf --install > /dev/null 2>&1 || autoreconf &&
@@ -21,6 +22,7 @@ ExternalProject_Add(pbc
                     $ENV{CONFIGURE_ARGS}
                     CC=${CMAKE_C_COMPILER}
                     CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
+                    CPPFLAGS=-I${GMP_INCLUDE_DIR}
                     LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib
   BUILD_COMMAND     make -j
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libpbc.a
@@ -41,6 +43,6 @@ set_target_properties(PBC::PBC
   )
 target_link_libraries(PBC::PBC
   INTERFACE
-  gmp
+  GMP::gmp
   )
 add_dependencies(PBC::PBC pbc)


### PR DESCRIPTION
macOS, or more likely apple's clang, doesn't look in `/usr/include` anymore. Or, least I _think_ so. Either way, let's explicitly do a package search `gmp` and manually pass its header path via `pbc`'s `CPPFLAGS`. 
