### PR TITLE
Enable cross-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # erlang-pbc
 
 ![CI](https://github.com/helium/erlang-pbc/workflows/CI/badge.svg)
+
+Building
+--------
+
+Fork the repo and simply use `make` to build the library. You will
+need `cmake` installed to build the NIFs.
+
+To run the tests run `make test`.
+
+## Cross compilation
+
+Cross-compilation requires the environment variable `ERTS_INCLUDE_DIR`
+defined as the target directory containing `erl_nif.h`,
+e.g. `ERTS_INCLUDE_DIR=target/usr/lib/erlang/erts-<VERSION>/include`.

--- a/c_src/cmake/FindGMP.cmake
+++ b/c_src/cmake/FindGMP.cmake
@@ -50,8 +50,8 @@ find_package(PkgConfig QUIET)
 pkg_check_modules(PKG QUIET gmp gmpxx)
 
 # Try to locate the libraries and their headers, using pkg-config hints
-find_path(GMP_INCLUDE_DIR gmp.h HINTS ${PKG_gmp_INCLUDEDIR})
-find_library(GMP_LIB gmp HINTS ${PKG_gmp_LIBDIR})
+find_path(GMP_INCLUDE_DIR gmp.h HINTS ${PKG_gmp_INCLUDEDIR} $ENV{CMAKE_INCLUDE_DIR})
+find_library(GMP_LIB gmp HINTS ${PKG_gmp_LIBDIR} $ENV{CMAKE_LIBRARY_PATH})
 
 # Remove these variables from cache inspector
 mark_as_advanced(GMP_INCLUDE_DIR GMP_LIB)


### PR DESCRIPTION
This package can not be cross-compiled becuase uncondition execution of erl in FindErlang.cmake. To fix that problem, this PR:

Cuts down FindErlang.cmake to only what this library needs.
Skips erl execution if the semi-standard environment variable ERTS_INCLUDE_DIR is set.

Closes #9 