### PR TITLE
Update GMP target to include a directory property.

### DIFF
--- a/c_src/cmake/FindGMP.cmake
+++ b/c_src/cmake/FindGMP.cmake
@@ -68,8 +68,10 @@ if(GMP_FOUND)
   # C library
   if(NOT TARGET GMP::gmp)
     add_library(GMP::gmp UNKNOWN IMPORTED)
+    get_filename_component(GMP_LIB_DIR ${GMP_LIB} DIRECTORY)
     set_target_properties(GMP::gmp PROPERTIES
       IMPORTED_LOCATION ${GMP_LIB}
+      IMPORTED_DIRECTORY ${GMP_LIB_DIR}
       INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
       )
   endif()

--- a/c_src/cmake/FindPBC.cmake
+++ b/c_src/cmake/FindPBC.cmake
@@ -6,10 +6,12 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
 endif()
 
+get_target_property(GMP_LIB_DIR GMP::gmp IMPORTED_DIRECTORY)
+
 ExternalProject_Add(pbc
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/external-pbc
   GIT_REPOSITORY    https://github.com/Vagabond/pbc
-  GIT_TAG           cbe5718309e2c34345a35eb76731fb81122f0d79
+  GIT_TAG           ddd8ce61b203a692cbf5cb4bc14886b85e828e5f
   UPDATE_COMMAND    ""
   BUILD_IN_SOURCE   1
   CONFIGURE_COMMAND autoreconf --install > /dev/null 2>&1 || autoreconf &&
@@ -23,10 +25,10 @@ ExternalProject_Add(pbc
                     CC=${CMAKE_C_COMPILER}
                     CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
                     CPPFLAGS=-I${GMP_INCLUDE_DIR}
-                    LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib
-  BUILD_COMMAND     make -j
+                    LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib\ -L${GMP_LIB_DIR}
+  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libpbc.a
-  INSTALL_COMMAND   make install
+  INSTALL_COMMAND   ${CMAKE_BUILD_TOOL} install
   )
 
 # Hack to let us declare a not-yet-existing include path below.


### PR DESCRIPTION
Once libgmp is found, make sure to record the directory in which it was found so that
LDFLAGS can be updated (later) when calling `configure` for the library. This makes
it possible to build the project on platforms where `libgmp.a` may be in a place such
as `/usr/local/lib`, perhaps.