### PR TITLE
Fix cross compilation

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##########################################################################
 # Project Setup                                                          #
 ##########################################################################
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.11)
 
 if(DEFINED ENV{CMAKE_TOOLCHAIN_FILE})
   set(CMAKE_TOOLCHAIN_FILE $ENV{CMAKE_TOOLCHAIN_FILE})

--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -2,6 +2,11 @@
 # Project Setup                                                          #
 ##########################################################################
 cmake_minimum_required(VERSION 3.3)
+
+if(DEFINED ENV{CMAKE_TOOLCHAIN_FILE})
+  set(CMAKE_TOOLCHAIN_FILE $ENV{CMAKE_TOOLCHAIN_FILE})
+endif()
+
 project(ErlangPBC C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 99)

--- a/c_src/cmake/FindPBC.cmake
+++ b/c_src/cmake/FindPBC.cmake
@@ -8,9 +8,8 @@ endif()
 
 get_target_property(GMP_LIB_DIR GMP::gmp IMPORTED_DIRECTORY)
 
-if(DEFINED ENV{CONFIGURE_ARGS})
-  string(REPLACE " " ";" CONFIGURE_ARGS $ENV{CONFIGURE_ARGS})
-endif()
+set(CONFIGURE_ARGS $ENV{CONFIGURE_ARGS})
+separate_arguments(CONFIGURE_ARGS)
 
 ExternalProject_Add(pbc
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/external-pbc

--- a/c_src/cmake/FindPBC.cmake
+++ b/c_src/cmake/FindPBC.cmake
@@ -8,6 +8,10 @@ endif()
 
 get_target_property(GMP_LIB_DIR GMP::gmp IMPORTED_DIRECTORY)
 
+if(DEFINED ENV{CONFIGURE_ARGS})
+  string(REPLACE " " ";" CONFIGURE_ARGS $ENV{CONFIGURE_ARGS})
+endif()
+
 ExternalProject_Add(pbc
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/external-pbc
   GIT_REPOSITORY    https://github.com/Vagabond/pbc
@@ -21,7 +25,7 @@ ExternalProject_Add(pbc
                     --disable-shared
                     --enable-optimized
                     --enable-safe-clean
-                    $ENV{CONFIGURE_ARGS}
+                    ${CONFIGURE_ARGS}
                     CC=${CMAKE_C_COMPILER}
                     CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
                     CPPFLAGS=-I${GMP_INCLUDE_DIR}

--- a/c_src/cmake/FindPBC.cmake
+++ b/c_src/cmake/FindPBC.cmake
@@ -11,6 +11,10 @@ get_target_property(GMP_LIB_DIR GMP::gmp IMPORTED_DIRECTORY)
 set(CONFIGURE_ARGS $ENV{CONFIGURE_ARGS})
 separate_arguments(CONFIGURE_ARGS)
 
+set(CONFIGURE_CFLAGS   "$ENV{CFLAGS}   ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}")
+set(CONFIGURE_CPPFLAGS "$ENV{CPPFLAGS} -I${GMP_INCLUDE_DIR}")
+set(CONFIGURE_LDFLAGS  "$ENV{LDFLAGS}  -L${CMAKE_CURRENT_BINARY_DIR}/lib\ -L${GMP_LIB_DIR}")
+
 ExternalProject_Add(pbc
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/external-pbc
   GIT_REPOSITORY    https://github.com/Vagabond/pbc
@@ -26,9 +30,9 @@ ExternalProject_Add(pbc
                     --enable-safe-clean
                     ${CONFIGURE_ARGS}
                     CC=${CMAKE_C_COMPILER}
-                    CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
-                    CPPFLAGS=-I${GMP_INCLUDE_DIR}
-                    LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib\ -L${GMP_LIB_DIR}
+                    CFLAGS=${CONFIGURE_CFLAGS}
+                    CPPFLAGS=${CONFIGURE_CPPFLAGS}
+                    LDFLAGS=${CONFIGURE_LDFLAGS}
                     ${APPLE_SDKROOT_ENV}
   BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j ${APPLE_SDKROOT_ENV}
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libpbc.a


### PR DESCRIPTION
This PR:

- unquotes multi-part configure arguments defined in the environment variable `CONFIGURE_ARGS` by converting them to list before passing them to `./confiure`
- if defined, uses the environment variable `CMAKE_TOOLCHAIN_FILE` 
  - this would normally be defined on the command line invocation of cmake, but that doean't work with deeply nested dependencies
- sets the correct minimum required cmake version (3.11)

CC: @benoitduffez
